### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/ProcComs/ProcComs.cpp
+++ b/ProcComs/ProcComs.cpp
@@ -129,8 +129,6 @@ void wmain(int argc, WCHAR *argv[])
 
     if (!CreateEnvironmentBlock(&lpvEnv, hToken, TRUE))    ShowLastError(L"CreateEnvironmentBlock");
 
-    dwSize = sizeof(szUserProfile)/sizeof(WCHAR);
-
     if (!GetUserProfileDirectory(hToken, szUserProfile, &dwSize))        ShowLastError(L"GetUserProfileDirectory");
     //
     // TO DO: change NULL to '.' to use local account database

--- a/RemCom.cpp
+++ b/RemCom.cpp
@@ -1097,10 +1097,10 @@ BOOL ExecuteRemoteCommand()
 
 	if ( response.dwErrorCode == 0 ) 
 		_ftprintf( stderr, _T("\nRemote command returned %d(0x%X)\n"), 
-		response.dwReturnCode );
+		response.dwReturnCode, response.dwReturnCode);
 	else
 		_ftprintf( stderr, _T("\nRemote command failed to start. Returned error code is %d(0x%X)\n"), 
-		response.dwErrorCode );
+		response.dwErrorCode, response.dwReturnCode);
 
 	return response.dwErrorCode;
 }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V519](https://www.viva64.com/en/w/v519/) The 'dwSize' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 121, 132. proccoms.cpp 132
[V576](https://www.viva64.com/en/w/v576/) Incorrect format. A different number of actual arguments is expected while calling 'fprintf' function. Expected: 4. Present: 3. remcom.cpp 1099, 1102